### PR TITLE
feat: userとfarmにてそれぞれrelation先のデータが取得できるように対応を入れた

### DIFF
--- a/backend/src/farm/farm.service.ts
+++ b/backend/src/farm/farm.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { CreateFarmInput } from './dto/create-farm.input';
 import { Farm } from '@/farm/entities/farm.entity';
-import { DataSource } from 'typeorm';
+import { DataSource, FindOptionsRelations } from 'typeorm';
 import { UserService } from '@/user/user.service';
 
 @Injectable()
@@ -10,6 +10,12 @@ export class FarmService {
     private readonly dataSource: DataSource,
     private readonly userService: UserService,
   ) { }
+
+  async findAll(relations: FindOptionsRelations<Farm>): Promise<Farm[]> {
+    return this.dataSource.getRepository(Farm).find({
+      relations,
+    });
+  }
 
   async create(createFarmInput: CreateFarmInput): Promise<Farm> {
     const user = await this.userService.findOne(createFarmInput.ownerId);

--- a/backend/src/schema.gql
+++ b/backend/src/schema.gql
@@ -42,6 +42,7 @@ type Mutation {
 }
 
 type Query {
+  farms: [Farm!]!
   users: [User!]!
 }
 

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { DataSource } from 'typeorm';
+import { DataSource, FindOptionsRelations } from 'typeorm';
 import { User } from './user.entity';
 import { CreateUserInput } from '@/user/dto/create-user.input';
 
@@ -7,8 +7,10 @@ import { CreateUserInput } from '@/user/dto/create-user.input';
 export class UserService {
   constructor(private readonly dataSource: DataSource) { }
 
-  async findAll(): Promise<User[]> {
-    return this.dataSource.getRepository(User).find();
+  async findAll(relations: FindOptionsRelations<User>): Promise<User[]> {
+    return this.dataSource.getRepository(User).find({
+      relations,
+    });
   }
 
   async checkEmail(email: string): Promise<boolean> {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - GraphQLスキーマに新しいクエリ「farms」を追加し、全ての農場情報を取得可能になりました。
- **改善**
  - 「users」および「farms」クエリで、リクエスト内容に応じて関連情報（所有者や農場）を自動で含めるようになり、必要な情報のみ効率的に取得できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->