### PR TITLE
feat: farmの単数のquery処理とrelation先を指定して在庫があるデータのみを表示できるようにした

### DIFF
--- a/backend/src/farm/farm.resolver.ts
+++ b/backend/src/farm/farm.resolver.ts
@@ -15,12 +15,41 @@ export class FarmResolver {
   @Query(() => [Farm])
   async farms(@Info() info: GraphQLResolveInfo) {
     const selections = info.fieldNodes[0].selectionSet?.selections;
-    const hasOwner = selections?.some(
-      (selection) =>
-        selection.kind === Kind.FIELD && selection.name.value === 'owner',
-    );
-    const relations = hasOwner ? { owner: true } : {};
+
+    const relationKeys = ['owner', 'produceItems', 'produceStocks'];
+    const relations: Record<string, boolean> = {};
+
+    for (const key of relationKeys) {
+      const hasField = selections?.some(
+        (selection) =>
+          selection.kind === Kind.FIELD && selection.name.value === key,
+      );
+      if (hasField) {
+        relations[key] = true;
+      }
+    }
+
     return this.farmService.findAll(relations);
+  }
+
+  @Query(() => Farm)
+  async farm(@Args('id') id: number, @Info() info: GraphQLResolveInfo) {
+    const selections = info.fieldNodes[0].selectionSet?.selections;
+    const relations: Record<string, boolean> = {};
+
+    const relationKeys = ['owner', 'produceItems', 'produceStocks'];
+    for (const key of relationKeys) {
+      const hasField = selections?.some(
+        (selection) =>
+          selection.kind === Kind.FIELD && selection.name.value === key,
+      );
+      if (hasField) {
+        relations[key] = true;
+      }
+    }
+    return this.farmService.findOne(id, relations, {
+      filterProduceStock: true,
+    });
   }
 
   @UseGuards(RolesGuard)

--- a/backend/src/schema.gql
+++ b/backend/src/schema.gql
@@ -72,6 +72,7 @@ type ProduceStock {
 }
 
 type Query {
+  farm(id: Float!): Farm!
   farms: [Farm!]!
   users: [User!]!
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 指定したIDで単一の農場情報を取得できる新しいGraphQLクエリ（farm）が追加されました。
  - 農場情報取得時に、関連するオーナーや生産品、在庫情報も動的に取得できるようになりました。

- **改善**
  - 在庫がある生産品のみを条件に絞って取得できるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->